### PR TITLE
Add compatibility to 10.13 High Sierra

### DIFF
--- a/BT-LinkkeySync.py
+++ b/BT-LinkkeySync.py
@@ -12,8 +12,13 @@ print("---------------------------------")
 # file where the registry info shall be stored
 filename = 'btkeys.reg'
 
+highSierraLoc = False # change to true if running high sierra
+
 print("> get Bluetooth Link Keys from macOS and store it to blued.plist")
-output = subprocess.check_output("sudo defaults export /private/var/root/Library/Preferences/blued.plist ./blued.plist", shell=True)
+if not highSierraLoc:
+	output = subprocess.check_output("sudo defaults export /private/var/root/Library/Preferences/blued.plist ./blued.plist", shell=True)
+else:
+	output = subprocess.check_output("sudo defaults export /private/var/root/Library/Preferences/com.apple.bluetoothd.plist ./blued.plist", shell=True)
 
 print("> convert exported list from binary to xml")
 output = subprocess.check_output("sudo plutil -convert xml1 ./blued.plist", shell=True)


### PR DESCRIPTION
The location of LinkKeys changed in 10.13. This adds a bool that can be set in the script to pull the keys from the new location.

This should deal with issue #4 raised by @diepnt90.