### PR TITLE
Update psexec URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It generates a registry file for windows on macOS, which can afterwards be impor
 2. Mark the script as executable with `sudo chmod +x BT-Linkkeysync.py`
 3. Run the script with `sudo ./BT-Linkkeysync.py`(you will be asked for your password)
 4. Store the generated file `btkeys.reg` file to a location accessible by windows.
-5. Download [psexec](https://technet.microsoft.com/de-de/sysinternals/pxexec.aspx)
+5. Download [psexec](https://docs.microsoft.com/sysinternals/downloads/psexec)
    and store it to `C:/Windows/System32/`
 6. Run the command:
    `psexec -s -i regedit`


### PR DESCRIPTION
The current psexec URL isn't valid anymore (and specified a de-de locale).