### PR TITLE
Update BT-LinkkeySync.py

### DIFF
--- a/BT-LinkkeySync.py
+++ b/BT-LinkkeySync.py
@@ -6,7 +6,7 @@ from pprint import *
 import subprocess
 
 print("---------------------------------")
-print("  BT-Linkkeysync by DigitalBird")
+print("  BT-Linkkeysync by DigitalByrd")
 print("---------------------------------")
 
 # file where the registry info shall be stored
@@ -15,7 +15,7 @@ filename = 'btkeys.reg'
 highSierraLoc = False # change to True if running high sierra
 
 print("> get Bluetooth Link Keys from macOS and store it to blued.plist")
-if not highSierraLoc:
+if highSierraLoc:
 	output = subprocess.check_output("sudo defaults export /private/var/root/Library/Preferences/blued.plist ./blued.plist", shell=True)
 else:
 	output = subprocess.check_output("sudo defaults export /private/var/root/Library/Preferences/com.apple.bluetoothd.plist ./blued.plist", shell=True)
@@ -26,7 +26,7 @@ output = subprocess.check_output("sudo plutil -convert xml1 ./blued.plist", shel
 print("> parse the converted plist")
 pl = readPlist("./blued.plist")
 
-# print the content in a human readable forat
+# print the content in a human readable format
 #pprint(pl)
 
 # open the file where we write the registry information
@@ -62,29 +62,29 @@ if "SMPDistributionKeys" in pl:
 		# loop over all available devices of this adapter
 		for device in pl["SMPDistributionKeys"][adapter].keys():
 			dev = '\r\n\r\n[HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\BTHPORT\\Parameters\\Keys\\'+adapter.replace("-","")+'\\'+device.replace("-","") +"]"
-			
+
 			# Lonk-Term Key (LTK)
 			# 128-bit key used to generate the session key for an encrypted connection.
-			dev += '\r\n"LTK"=hex:'+ convertToWinRep(pl["SMPDistributionKeys"][adapter][device]["LTK"].data.hex())
+			dev += '\r\n"LTK"=hex:'+ convertToWinRep(pl["SMPDistributionKeys"][adapter][device]["LTK"].data.encode('hex'))
 			
 			#dev += '\r"KeyLength"=dword:00000000' # Don't know why this is zero when i pair my BT LE Mouse with windows.
-			dev += '\r\n"KeyLength"=dword:'+ pl["SMPDistributionKeys"][adapter][device]["LTKLength"].data.hex().rjust(8,'0')
+			dev += '\r\n"KeyLength"=dword:'+ pl["SMPDistributionKeys"][adapter][device]["LTKLength"].data.encode('hex').rjust(8,'0')
 
 			# Random Number (RAND):
 			# 64-bit stored value used to identify the LTK. A new RAND is generated each time a unique LTK is distributed.
-			dev += '\r\n"ERand"=hex(b):'+ convertToWinRep(pl["SMPDistributionKeys"][adapter][device]["RAND"].data.hex())
+			dev += '\r\n"ERand"=hex(b):'+ convertToWinRep(pl["SMPDistributionKeys"][adapter][device]["RAND"].data.encode('hex'))
 
 			# Encrypted Diversifier (EDIV)
 			# 16-bit stored value used to identify the LTK. A new EDIV is generated each time a new LTK is distributed.
-			dev += '\r\n"EDIV"=dword:'+ pl["SMPDistributionKeys"][adapter][device]["EDIV"].data.hex().rjust(8,'0')
+			dev += '\r\n"EDIV"=dword:'+ pl["SMPDistributionKeys"][adapter][device]["EDIV"].data.encode('hex').rjust(8,'0')
 
 			# Identity Resolving Key (IRK)
 			# 128-bit key used to generate and resolve random address.
-			dev += '\r\n"IRK"=hex:'+ convertToWinRep(pl["SMPDistributionKeys"][adapter][device]["IRK"].data.hex())
+			dev += '\r\n"IRK"=hex:'+ convertToWinRep(pl["SMPDistributionKeys"][adapter][device]["IRK"].data.encode('hex'))
 
 			# Device Address
 			# 48-bit Address of the connected device
-			dev += '\r\n"Address"=hex(b):'+ convertToWinRep(pl["SMPDistributionKeys"][adapter][device]["Address"].data.hex().rjust(16,'0'))
+			dev += '\r\n"Address"=hex(b):'+ convertToWinRep(pl["SMPDistributionKeys"][adapter][device]["Address"].data.encode('hex').rjust(16,'0'))
 
 			# Don't know whats that, i'm using an Logitech MX Master, and this is written to the registry when i pair it to windows
 			dev += '\r\n"AddressType"=dword:00000001'
@@ -99,6 +99,7 @@ else:
 	print("No Bluetooth 4.0 information available")
 
 f.close()
+
 print("> Registry file generated and ready for import")
 
 


### PR DESCRIPTION
Run on Catalina now, some problem with finding the right plist so I reversed the if logic. Hex encoding is now fixed. Importing the resulting reg file in Windows does nothing.